### PR TITLE
Returns this instead of true if MyO is already locked

### DIFF
--- a/myo.js
+++ b/myo.js
@@ -194,7 +194,7 @@
 			}
 		},
 		lock : function(){
-			if(this.isLocked) return true;
+			if(this.isLocked) return this;
 
 			Myo.socket.send(JSON.stringify(["command", {
 				"command": "lock",


### PR DESCRIPTION
Tiny fix, the `.lock` method returns `true` if the MyO is already locked, but returns `this` on a normal lock and most of other methods.

Returning `true` would certainly break any implemented chains, so I changed it to the regular `this`.
