### PR TITLE
Adding default app ID to socket url

### DIFF
--- a/myo.js
+++ b/myo.js
@@ -10,7 +10,7 @@
 	Myo = {
 		defaults : {
 			api_version : 3,
-			socket_url  : "ws://127.0.0.1:10138/myo/",
+			socket_url  : "ws://127.0.0.1:10138/myo/?appid=com.myojs.default",
 		},
 		lockingPolicy : 'standard',
 		events : [],


### PR DESCRIPTION
As per the documentation [here](https://developer.thalmic.com/forums/topic/534/), adding a default application id for myo.js. In the future it would be good to expose this so individual apps can easily set their own ids.
