### PR TITLE
Fixed pairing to avoid duplicated myo on reconnect

### DIFF
--- a/myo.js
+++ b/myo.js
@@ -60,11 +60,17 @@
 			var data = JSON.parse(msg.data)[1];
 			if(!data.type || typeof(data.myo) === 'undefined') return;
 			if(data.type == 'paired'){
-				Myo.myos.push(Myo.create({
-					macAddress      : data.mac_address,
-					name            : data.name,
-					connectIndex    : data.myo
-				}));
+				var exists = Myo.myos.some(function(myo) {
+					return myo.macAddress == data.mac_address;
+				});
+
+				if (!exists) {
+					Myo.myos.push(Myo.create({
+						macAddress      : data.mac_address,
+						name            : data.name,
+						connectIndex    : data.myo
+					}));
+				}
 			}
 
 			Myo.myos.map(function(myo){


### PR DESCRIPTION
When connecting and disconnecting multiple times from Myo, paired Myos will be duplicated on every reconnection. Imagine a scenario where we have only one Myo paired:

``` javascript
Myo.on('connected', function() {
  console.log(Myo.myos.length);
};

Myo.connect();
...
// prints 1
...
Myo.disconnect();
...
Myo.connect();
...
// prints 2
...
Myo.disconnect();
```

Myo will be readded even if it is already registered in the list. Therefore I fixed the code on the pairing event by checking if the MAC address of the paired device is not already registered.
