### PR TITLE
fixed issue #25 which crash when using node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript bindings for Myo",
   "main": "myo.js",
   "dependencies": {
-    "ws": "^0.4.32"
+    "ws": "^1.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
update dependency ws version to 1.1.1,  previous ws version doesn't work with node 6.2.0 and above